### PR TITLE
Save build timestamp for cache buster use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ build:
 	@ make scripts
 	@ make fonts
 	@ make images
+	@ date +%Y%m%d%H%M%S > dist/version
 
 styles:
 	@ echo "› Building styles:"


### PR DESCRIPTION
Allow php to enqueue assets with versioning, for cache busting purpose.

Example (WordPress) :

```php
function get_version() {
  static $version;

  if(!isset($version)) {
    $version_path = get_template_directory() . '/dist/version';
    if(!file_exists($version_path)) {
      $version = false;
    } else {
      $version = intval(file_get_contents($version_path));
    }
  }

  return $version;
}
```